### PR TITLE
refactor: convert colors array to object

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,25 +4,24 @@ const cursorColor = 'rgba(181, 137, 0, 0.6)'
 const borderColor = 'rgba(38, 139, 210, 0.3)'
 const activeTabBorderColor = '#2aa198' // cyan
 
-const colors = [
-  backgroundColor,
-  '#dc322f', // red
-  '#859900', // green
-  '#b58900', // yellow
-  '#268bd2', // blue
-  '#6c71c4', // violet
-  '#2aa198', // cyan
-  '#eee8d5', // light gray
-  '#586e75', // medium gray
-  '#dc322f', // red
-  '#586e75', // green
-  '#657b83', // yellow
-  '#839496', // blue
-  '#6c71c4', // violet
-  '#2aa198', // cyan
-  '#ffffff', // white
-  foregroundColor
-]
+const colors = {
+  black:          '#002b36',
+  red:            '#dc322f',
+  green:          '#859900',
+  yellow:         '#b58900',
+  blue:           '#268bd2',
+  magenta:        '#6c71c4',
+  cyan:           '#2aa198',
+  white:          '#eee8d5',
+  lightBlack:     '#586e75',
+  lightRed:       '#dc322f',
+  lightGreen:     '#586e75',
+  lightYellow:    '#657b83',
+  lightBlue:      '#839496',
+  lightMagenta:   '#6c71c4',
+  lightCyan:      '#2aa198',
+  lightWhite:     '#ffffff',
+}
 
 
 


### PR DESCRIPTION
Because:
1. Hyperterm [now uses a color object by default](https://github.com/zeit/hyperterm/pull/193/commits/970eac21cc6ac9f93083c3b9d3f8ac7edbb6fe2a#diff-1dfee92b62e747055fc44e019d136750R30)
2. An object (hash table) is a better fit for this (you can drop the comments)
