### PR TITLE
Truly fix the colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,22 +5,22 @@ const borderColor = 'rgba(38, 139, 210, 0.3)'
 const activeTabBorderColor = '#2aa198' // cyan
 
 const colors = {
-  black:          '#002b36',
-  red:            '#dc322f',
-  green:          '#859900',
-  yellow:         '#b58900',
-  blue:           '#268bd2',
-  magenta:        '#6c71c4',
-  cyan:           '#2aa198',
-  white:          '#eee8d5',
-  lightBlack:     '#586e75',
-  lightRed:       '#dc322f',
+  lightBlack:     '#002b36',
+  black:          '#073642',
   lightGreen:     '#586e75',
   lightYellow:    '#657b83',
   lightBlue:      '#839496',
+  lightCyan:      '#93a1a1',
+  white:          '#eee8d5',
+  lightWhite:     '#fdf6e3',
+  yellow:         '#b58900',
+  lightRed:       '#cb4b16',
+  red:            '#dc322f',
+  magenta:        '#d33682',
   lightMagenta:   '#6c71c4',
-  lightCyan:      '#2aa198',
-  lightWhite:     '#ffffff',
+  blue:           '#268bd2',
+  cyan:           '#2aa198',
+  green:          '#859900'
 }
 
 

--- a/index.js
+++ b/index.js
@@ -4,25 +4,24 @@ const cursorColor = 'rgba(181, 137, 0, 0.6)'
 const borderColor = 'rgba(38, 139, 210, 0.3)'
 const activeTabBorderColor = '#2aa198' // cyan
 
-const colors = [
-  backgroundColor,
-  '#dc322f', // red
-  '#859900', // green
-  '#b58900', // yellow
-  '#268bd2', // blue
-  '#6c71c4', // violet
-  '#2aa198', // cyan
-  '#eee8d5', // light gray
-  '#586e75', // medium gray
-  '#dc322f', // red
-  '#586e75', // green
-  '#657b83', // yellow
-  '#839496', // blue
-  '#6c71c4', // violet
-  '#2aa198', // cyan
-  '#ffffff', // white
-  foregroundColor
-]
+const colors = {
+  black:          '#002b36',
+  red:            '#dc322f',
+  green:          '#859900',
+  yellow:         '#b58900',
+  blue:           '#268bd2',
+  magenta:        '#6c71c4',
+  cyan:           '#2aa198',
+  white:          '#eee8d5',
+  lightBlack:     '#586e75',
+  lightRed:       '#dc322f',
+  lightGreen:     '#586e75',
+  lightYellow:    '#657b83',
+  lightBlue:      '#839496',
+  lightMagenta:   '#6c71c4',
+  lightCyan:      '#2aa198',
+  lightWhite:     '#ffffff',
+}
 
 
 


### PR DESCRIPTION
While the current colors look good, they don't exactly match the spec which happens to mess up vim.

My refactor commit which converts `colors` from an array to object helps clarify the discrepancy from [the spec](http://ethanschoonover.com/solarized). ([the default Hyperterm config now uses a color object](https://github.com/altercation/vim-colors-solarized/blob/528a59f26d12278698bb946f8fb82a63711eec21/doc/solarized.txt#L187)) It helps clarify the problem because the colors in this theme are now named according to the terminal color names. 

Below is the spec table. The `br...` colors correspond to `light...` colors in the color object. This is because generally the lighter colors are used as text highlights (or background).

![table](https://cloud.githubusercontent.com/assets/8813276/17987107/c9ec5090-6ae3-11e6-81e9-2094a4c0c564.png)
#2 only fixed the colors partially. The reason it fixed it for him is because he is using `let g:solarized_termtrans = 1` which [should **not** be needed](https://github.com/altercation/vim-colors-solarized/blob/528a59f26d12278698bb946f8fb82a63711eec21/doc/solarized.txt#L187) when the terminal is using the correct solarized colors.
# Before

![broke](https://cloud.githubusercontent.com/assets/8813276/17987163/1c195cc8-6ae4-11e6-8f14-c07aa0526425.png)
# After

![fixed](https://cloud.githubusercontent.com/assets/8813276/17987169/2134b3a6-6ae4-11e6-8242-256d5a438f91.png)
