### PR TITLE
Change `hyperterm` to `hyper` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "hyperterm-solarized-dark",
   "version": "0.1.8",
-  "description": "Hyperterm theme using the dark Solarized colors",
+  "description": "Hyper theme using the dark Solarized colors",
   "main": "index.js",
   "keywords": [
-    "hyperterm",
-    "hyperterm-theme",
+    "hyper",
+    "hyper-theme",
     "colors",
     "theme",
     "solarized"


### PR DESCRIPTION
Because: https://hyper.is/#extensions

I left the name as-is, because I'm not sure if you want to change it, but I think it's probably best to change it too.
