### PR TITLE
Typo in the related part of the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ A port of the [Solarized Dark](http://ethanschoonover.com/solarized) theme for [
 
 
 ### Related
-- [Solarized Light Theme](https://github.com/Ghosh/hyper-solarized-dark)
+- [Solarized Light Theme](https://github.com/Ghosh/hyper-solarized-light)
 
 ```
 License - MIT


### PR DESCRIPTION
Hi!
The link for the Solarized Light Theme redirect to Solarized Dark Theme.
Thank you