### PR TITLE
no !important or ligatures

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,32 +38,32 @@ exports.decorateConfig = config => {
     css: `
       ${config.css || ''}
       * {
-      	-webkit-font-feature-settings: "liga" on, "calt" on, "dlig" on !important;
-      	text-rendering: optimizeLegibility !important;
+      	-webkit-font-feature-settings: "liga" on, "calt" on, "dlig" on;
+      	text-rendering: optimizeLegibility;
         font-weight: 500;
       }
       .tabs_list {
       	border: 0;
       }
       .tabs_nav {
-      	background-color: #001f27 !important;
+      	background-color: #001f27;
       }
       .tab_tab {
-        color: ${foregroundColor} !important;
+        color: ${foregroundColor};
         background-color: #001f27;
-				border-color: ${borderColor} !important;
+				border-color: ${borderColor};
       }
       .tab_tab:before {
       	border: 0;
       }
       .tab_tab.tab_active {
-        border: transparent !important;
+        border: transparent;
         font-weight: bold;
-        color: #b3b3b3 !important;
+        color: #b3b3b3;
         background-color: ${backgroundColor};
       }
       .splitpane_divider {
-      	background-color: #001f27 !important;
+      	background-color: #001f27;
       }
     `
   })

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ exports.decorateConfig = config => {
     css: `
       ${config.css || ''}
       * {
-      	-webkit-font-feature-settings: "liga" on, "calt" on, "dlig" on;
       	text-rendering: optimizeLegibility;
         font-weight: 500;
       }


### PR DESCRIPTION
-   as discussed, drop the font-feature-settings rule that enables ligatures, in favour of allowing users to control this elsewhere (fixes #13)
-   also dropped the `!important` property from rules, so that these are more easily adjusted by users elsewhere
-   tested this against Hyper 1.4 and 2.0, without any obvious regressions found
