### PR TITLE
windows-color-fix: Changed foreground and background colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const backgroundColor = '#002b36'
-const foregroundColor = '#839496'
+const backgroundColor = '#073642'
+const foregroundColor = '#eee8d5'
 const cursorColor = 'rgba(181, 137, 0, 0.6)'
 const borderColor = 'transparent'
 


### PR DESCRIPTION
On windows, the 16 colors visible to the console map out like so:

    0 -> backgroundColor
    1 -> blue
    2 -> green
    3 -> cyan
    4 -> red
    5 -> magenta
    6 -> yellow
    7 -> lightWhite
    8 -> lightBlack
    9 -> lightBlue
    10 -> lightGreen
    11 -> lightCyan
    12 -> lightRed
    13 -> lightMagenta
    14 -> lightYellow
    15 -> foregroundColor

As you can see black (which maps to base02 in solarized) and white
(which maps to base2 in solarized) are not visible, meaning these colors
are missing on windows. To remedy this I changed the background colors
to base02 and foreground color to base2 to allow windows to use all 16
colors of solarized.