### PR TITLE
Make split pane divider visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.decorateConfig = config => {
         background-color: ${backgroundColor};
       }
       .splitpane_divider {
-      	background-color: #001f27;
+      	background-color: #586e75;
       }
     `
   })


### PR DESCRIPTION
The split pane divider isn't visible with the current configuration.

![image](https://user-images.githubusercontent.com/15050019/48891136-89a70500-ee32-11e8-8084-18bc1849af30.png)

Changing the configuration to the suggest colour gives a result that looks like

![image](https://user-images.githubusercontent.com/15050019/48891184-9d526b80-ee32-11e8-8963-a05202e04418.png)

Fixes #15 