### PR TITLE
Fix invisible lightBlack text

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cursorColor = 'rgba(181, 137, 0, 0.6)'
 const borderColor = 'transparent'
 
 const colors = {
-  lightBlack:     '#002b36',
+  lightBlack:     '#586e75',
   black:          '#073642',
   lightGreen:     '#586e75',
   lightYellow:    '#657b83',


### PR DESCRIPTION
Fixes ghosh/hyper-solarized-dark#11 which was introduced in https://github.com/ghosh/hyper-solarized-dark/commit/3a71436a38758336fbe87505995f8f22725f7f00. 

The issue was that `backgroundColor = '#002b36'` was set to the same exact color as `lightBlack: '#002b36'`, making any text colored with `lightBlack` invisible. This commit reverses the change introduced by the above commit.